### PR TITLE
Alpha-sort FreeSurfer ROIs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "description": "Single shot implementation of ridge regression in python for COINSTAC.",
   "dependencies": {
+    "alphanum-sort": "^1.0.2",
     "distributions": "^1.0.0",
     "freesurfer-parser": "0.0.2",
     "lodash": "^4.17.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const alphanumSort = require('alphanum-sort');
 const regression = require('./regression');
 const { DEFAULT_LAMBDA, DECLARATION_INPUTS_KEY } = require('./constants.js');
 const fs = require('fs');
@@ -136,7 +137,10 @@ module.exports = {
       help: 'Select Freesurfer region(s) of interest',
       label: 'Freesurfer ROI',
       type: 'select',
-      values: FreeSurfer.validFields,
+      values: alphanumSort(
+        FreeSurfer.validFields.filter(field => field !== 'header'),
+        { insensitive: true }
+      ),
     }, {
       defaultValue: DEFAULT_LAMBDA,
       label: 'Lambda',


### PR DESCRIPTION
* **Problem:** FreeSurfer ROIs are difficult to find in the UI (see MRN-Code/coinstac#150).
* **Solution:** Alpha-sort ROIs and remove the “header” field.
* **Testing:** View computation in UI.